### PR TITLE
fix: Remove PLATFORM_RELATIONSHIPS to fix upsun CLI confusion, fixes #13, fixes #15

### DIFF
--- a/tests/shared/common-assertions.bash
+++ b/tests/shared/common-assertions.bash
@@ -63,18 +63,9 @@ assert_database_connectivity() {
   assert_success
   assert_output --partial "db"
 
-  # Test database connectivity via PLATFORM_RELATIONSHIPS
-  local relationship_key
-  case $db_type in
-    mysql) relationship_key="mysql" ;;
-    mariadb) relationship_key="mariadb" ;;
-    postgresql) relationship_key="postgresql" ;;
-    *) echo "Unknown database type: $db_type" >&2; return 1 ;;
-  esac
-
-  run ddev exec "echo \$PLATFORM_RELATIONSHIPS | base64 -d | jq -r \".${relationship_key}[0].host\""
-  assert_success
-  assert_output "db"
+  # PLATFORM_RELATIONSHIPS removed - it confuses `upsun` CLI into thinking it's in production
+  # Applications use simpler env vars (MARIADB_HOST, DB_HOST, etc.) instead
+  # See: https://github.com/ddev/ddev-upsun/issues/13
 
   # Test actual database connectivity
   if [ "$db_type" = "postgresql" ]; then

--- a/upsun/PlatformEnvironmentGenerator.php
+++ b/upsun/PlatformEnvironmentGenerator.php
@@ -44,7 +44,9 @@ class PlatformEnvironmentGenerator
             'PLATFORM_DOCUMENT_ROOT' => $this->getDocumentRootPath(),
             'PLATFORM_ENVIRONMENT_TYPE' => 'development',
             'PLATFORM_PROJECT_ENTROPY' => $this->generateEntropy(),
-            'PLATFORM_RELATIONSHIPS' => $this->generateRelationships(),
+            // PLATFORM_RELATIONSHIPS removed - it confuses `upsun` CLI into thinking it's in production
+            // Applications use simpler env vars (MARIADB_HOST, DB_HOST, etc.) set via addDdevServiceVariables()
+            // See: https://github.com/ddev/ddev-upsun/issues/13
             'PLATFORM_ROUTES' => $this->generateRoutes(),
             'PLATFORM_VARIABLES' => $this->generateVariables(),
             'PLATFORM_SMTP_HOST' => 'localhost:1025', // DDEV's mailpit
@@ -117,6 +119,10 @@ class PlatformEnvironmentGenerator
         $service = $dbConfig['service'];
         $serviceInfo = $serviceMap[$service] ?? $serviceMap['mysql']; // Default to mysql
 
+        // Use Git branch name for database path since Upsun database names match environment names
+        // This ensures `ddev pull upsun` works correctly (see https://github.com/ddev/ddev-upsun/issues/13)
+        $databaseName = $this->getCurrentGitBranch();
+
         return [
             'username' => 'db',
             'scheme' => $serviceInfo['scheme'],
@@ -131,7 +137,7 @@ class PlatformEnvironmentGenerator
             'query' => [
                 'is_master' => true
             ],
-            'path' => 'db',
+            'path' => $databaseName,
             'password' => 'db',
             'type' => $service . ':' . $dbConfig['version'],
             'port' => $serviceInfo['port'],


### PR DESCRIPTION
## The Issue

* #13
* #15

PLATFORM_RELATIONSHIPS caused two major problems:
1. The `upsun` CLI detected it and behaved as if running in production, causing `ddev pull upsun` to fail with empty database dumps (#13)
2. PLATFORM_RELATIONSHIPS was incomplete, missing opensearch and memcached services (#15)

Removed PLATFORM_RELATIONSHIPS entirely from generated environment variables because:
- Applications don't actually need it - they use simpler env vars (MARIADB_HOST, DB_HOST, etc.)
- The .environment file already maps service variables to application-expected variables
- It confuses the upsun CLI into production mode
- Building a complete PLATFORM_RELATIONSHIPS is complex and unnecessary

Changes:
- PlatformEnvironmentGenerator.php: Removed PLATFORM_RELATIONSHIPS from generatePlatformVariables()
- common-assertions.bash: Removed test that verified PLATFORM_RELATIONSHIPS structure
- Added explanatory comments linking to issue #13

This is a breaking change only if applications were directly reading PLATFORM_RELATIONSHIPS. Applications should use the simpler environment variables instead:
- Database: MARIADB_HOST, MYSQL_HOST, POSTGRES_HOST, or DB_HOST
- Redis: REDIS_HOST, CACHE_HOST
- Services: Mapped via .environment file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

