### PR TITLE
feat: Add database version mapping with warnings for inexact matches, fixes #16

### DIFF
--- a/tests/per_test.sh
+++ b/tests/per_test.sh
@@ -7,6 +7,8 @@ per_test_setup() {
   echo "# doing 'ddev add-on get ${PROJECT_SOURCE:-}' PROJNAME=${PROJNAME:-} in TESTDIR=${TESTDIR:-} ($(pwd))" >&3
   run ddev add-on get ${PROJECT_SOURCE:-}
   assert_success
+  # Save add-on installation output for version warning tests
+  echo "$output" > .ddev/addon-install.log
 
   echo "# ddev start with PROJNAME=${PROJNAME:-} in ${TESTDIR:-} ($(pwd))" >&3
   run ddev start -y

--- a/tests/testdata/platform-configs/mariadb-inexact-fixed/.platform.app.yaml
+++ b/tests/testdata/platform-configs/mariadb-inexact-fixed/.platform.app.yaml
@@ -1,0 +1,51 @@
+# The name of this app. Must be unique within a project.
+name: drupal
+
+# The runtime the application uses.
+type: php:8.3
+
+# The relationships of the application with services or other applications.
+relationships:
+    database: 'db:mysql'
+    redis: 'cache:redis'
+
+# The configuration of app when it is exposed to the web.
+web:
+    locations:
+        "/":
+            root: "web"
+            expires: 5m
+            passthru: "/index.php"
+            allow: false
+            rules:
+                '\.(jpe?g|png|gif|svgz?|css|js|map|ico|bmp|eot|woff2?|otf|ttf)$':
+                    allow: true
+
+# The size of the persistent disk of the application (in MB).
+disk: 2048
+
+# The 'mounts' describe writable, persistent filesystem mounts in the application.
+mounts:
+    '/web/sites/default/files':
+        source: local
+        source_path: 'files'
+    '/tmp':
+        source: local
+        source_path: 'tmp'
+    '/private':
+        source: local
+        source_path: 'private'
+    '/.drush':
+        source: local
+        source_path: 'drush'
+    '/drush-backups':
+        source: local
+        source_path: 'drush-backups'
+
+# PHP extensions
+runtime:
+    extensions:
+        - redis
+        - sodium
+        - apcu
+        - blackfire

--- a/tests/testdata/platform-configs/mariadb-inexact-fixed/.platform/routes.yaml
+++ b/tests/testdata/platform-configs/mariadb-inexact-fixed/.platform/routes.yaml
@@ -1,0 +1,9 @@
+# The routes of the project.
+
+"https://{default}/":
+    type: upstream
+    upstream: "drupal:http"
+
+"https://www.{default}/":
+    type: redirect
+    to: "https://{default}/"

--- a/tests/testdata/platform-configs/mariadb-inexact-fixed/.platform/services.yaml
+++ b/tests/testdata/platform-configs/mariadb-inexact-fixed/.platform/services.yaml
@@ -1,0 +1,8 @@
+# The services of the project.
+
+db:
+    type: mariadb:11.0
+    disk: 2048
+
+cache:
+    type: redis:8.0

--- a/tests/testdata/platform-configs/mariadb-inexact-flex/.upsun/config.yaml
+++ b/tests/testdata/platform-configs/mariadb-inexact-flex/.upsun/config.yaml
@@ -1,0 +1,94 @@
+applications:
+  drupal:
+    source:
+      root: /
+    type: php:8.3
+    build:
+      flavor: composer
+    # Installs global dependencies as part of the build process. They're independent of your app's dependencies and
+    # are available in the PATH during the build process and in the runtime environment. They're installed before
+    # the build hook runs using a package manager for the language.
+    # More information: https://docs.upsun.com/create-apps/app-reference/single-runtime-image.html#dependencies
+    dependencies:
+      nodejs:
+        n: "*"
+        npx: "*"
+        yarn: "^1.22.0"
+      php:
+        composer/composer: "^2"
+
+    web:
+      locations:
+        "/":
+          root: "web"
+          expires: 5m
+          passthru: "/index.php"
+          allow: false
+          rules:
+            '\.(avif|webp|jpe?g|png|gif|svgz?|css|js|map|ico|bmp|eot|woff2?|otf|ttf)$':
+              allow: true
+            '^/robots\.txt$':
+              allow: true
+            '^/sitemap\.xml$':
+              allow: true
+            '^/sites/sites\.php$':
+              scripts: false
+            '^/sites/[^/]+/settings.*?\.php$':
+              scripts: false
+        "/sites/default/files":
+          root: "web/sites/default/files"
+          allow: true
+          expires: 5m
+          passthru: "/index.php"
+          scripts: false
+          rules:
+            '^/sites/default/files/(css|js)':
+              expires: 2w
+    variables:
+      env:
+        N_PREFIX: "/app/.global"
+
+    mounts:
+      "/web/sites/default/files": "shared:files/files"
+      "/tmp": "shared:files/tmp"
+      "/private": "shared:files/private"
+      "/.drush": "shared:files/drush"
+      "/drush-backups": "shared:files/drush-backups"
+    relationships:
+      mariadb: "mariadb:mysql"
+      redis: 'cache:redis'
+      opensearch: 'search:opensearch'
+      memcached: 'memory:memcached'
+
+    hooks:
+      build: |
+        set -e
+        # fast.
+      deploy: |
+        set -e
+        php ./drush/upsun_generate_drush_yml.php
+        cd web
+        bash $PLATFORM_APP_DIR/drush/upsun_deploy_drupal.sh
+
+    runtime:
+      # Enable the redis extension so Drupal can communicate with the Redis cache.
+      extensions:
+        - redis
+        - sodium
+        - apcu
+        - blackfire
+
+services:
+  mariadb:
+    type: mariadb:11.0
+  cache:
+    type: redis:8.0
+  search:
+    type: opensearch:3
+  memory:
+    type: memcached:1.6
+
+routes:
+  "https://{default}/":
+    type: upstream
+    upstream: "drupal:http"

--- a/upsun/DdevConfigGenerator.php
+++ b/upsun/DdevConfigGenerator.php
@@ -41,65 +41,100 @@ class DdevConfigGenerator
         'postgresql' => 'postgres'   // Upsun 'postgresql' -> DDEV 'postgres'
     ];
 
-    // Upsun database service -> supported versions (Upsun version -> DDEV version)
+    // Upsun database service -> supported versions mapping
+    // Each entry maps Upsun version => [DDEV version, exact match boolean]
+    // exact=true: Version is identical and fully supported
+    // exact=false: Mapped to next higher DDEV version (will trigger warning)
     private const DATABASE_VERSION_MAP = [
         // Oracle MySQL versions (oracle-mysql service in Upsun -> mysql in DDEV)
+        // DDEV supports MySQL: 5.5–8.0, 8.4
         'oracle-mysql' => [
-            '5.7' => '5.7',
-            '8.0' => '8.0',
-            '8.4' => '8.4'  // DDEV supports MySQL 8.4
+            // Exact matches
+            '5.5' => ['5.5', true],
+            '5.6' => ['5.6', true],
+            '5.7' => ['5.7', true],
+            '8.0' => ['8.0', true],
+            '8.4' => ['8.4', true],
+            // Inexact mappings (map to next higher supported version)
+            '8.1' => ['8.4', false],  // Map 8.1 -> 8.4 (next higher)
+            '8.2' => ['8.4', false],  // Map 8.2 -> 8.4 (next higher)
+            '8.3' => ['8.4', false],  // Map 8.3 -> 8.4 (next higher)
         ],
         // MariaDB versions (mysql/mariadb services in Upsun -> mariadb in DDEV)
-        // Note: mysql service in Upsun refers to MariaDB, not Oracle MySQL
+        // Note: Both 'mysql' and 'mariadb' service types in Upsun refer to MariaDB
+        // DDEV supports MariaDB: 5.5–10.8, 10.11, 11.4, 11.8
         'mysql' => [
-            // Current versions
-            '10.6' => '10.6',
-            '10.11' => '10.11',
-            '11.4' => '11.4',
-            '11.8' => '11.8',
-            // Deprecated versions (for legacy Platform.sh compatibility)
-            // DDEV supports MariaDB 5.5-10.8, 10.11, 11.4, 11.8
-            '5.5' => '5.5',
-            '10.0' => '10.0',   // Use exact versions where DDEV supports them
-            '10.1' => '10.1',
-            '10.2' => '10.2',
-            '10.3' => '10.3',
-            '10.4' => '10.4',
-            '10.5' => '10.5',
+            // Exact matches - Continuous range
+            '5.5' => ['5.5', true],
+            '10.0' => ['10.0', true],
+            '10.1' => ['10.1', true],
+            '10.2' => ['10.2', true],
+            '10.3' => ['10.3', true],
+            '10.4' => ['10.4', true],
+            '10.5' => ['10.5', true],
+            '10.6' => ['10.6', true],
+            '10.7' => ['10.7', true],
+            '10.8' => ['10.8', true],
+            '10.11' => ['10.11', true],
+            '11.4' => ['11.4', true],
+            '11.8' => ['11.8', true],
+            // Inexact mappings (map to next higher supported version)
+            // Note: DDEV has gaps - no 10.9, 10.10, 11.0-11.3, 11.5-11.7
+            '10.9' => ['10.11', false],   // Map 10.9 -> 10.11 (next higher)
+            '10.10' => ['10.11', false],  // Map 10.10 -> 10.11 (next higher)
+            '11.0' => ['11.4', false],    // Map 11.0 -> 11.4 (next higher)
+            '11.1' => ['11.4', false],    // Map 11.1 -> 11.4 (next higher)
+            '11.2' => ['11.4', false],    // Map 11.2 -> 11.4 (next higher)
+            '11.3' => ['11.4', false],    // Map 11.3 -> 11.4 (next higher)
+            '11.5' => ['11.8', false],    // Map 11.5 -> 11.8 (next higher)
+            '11.6' => ['11.8', false],    // Map 11.6 -> 11.8 (next higher)
+            '11.7' => ['11.8', false],    // Map 11.7 -> 11.8 (next higher)
         ],
         'mariadb' => [
-            // Current versions
-            '10.6' => '10.6',
-            '10.11' => '10.11',
-            '11.4' => '11.4',
-            '11.8' => '11.8',
-            // Deprecated versions (for legacy Platform.sh compatibility)
-            // DDEV supports MariaDB 5.5-10.8, 10.11, 11.4, 11.8
-            '5.5' => '5.5',
-            '10.0' => '10.0',   // Use exact versions where DDEV supports them
-            '10.1' => '10.1',
-            '10.2' => '10.2',
-            '10.3' => '10.3',
-            '10.4' => '10.4',
-            '10.5' => '10.5',
+            // Exact matches - Continuous range
+            '5.5' => ['5.5', true],
+            '10.0' => ['10.0', true],
+            '10.1' => ['10.1', true],
+            '10.2' => ['10.2', true],
+            '10.3' => ['10.3', true],
+            '10.4' => ['10.4', true],
+            '10.5' => ['10.5', true],
+            '10.6' => ['10.6', true],
+            '10.7' => ['10.7', true],
+            '10.8' => ['10.8', true],
+            '10.11' => ['10.11', true],
+            '11.4' => ['11.4', true],
+            '11.8' => ['11.8', true],
+            // Inexact mappings (map to next higher supported version)
+            // Note: DDEV has gaps - no 10.9, 10.10, 11.0-11.3, 11.5-11.7
+            '10.9' => ['10.11', false],   // Map 10.9 -> 10.11 (next higher)
+            '10.10' => ['10.11', false],  // Map 10.10 -> 10.11 (next higher)
+            '11.0' => ['11.4', false],    // Map 11.0 -> 11.4 (next higher)
+            '11.1' => ['11.4', false],    // Map 11.1 -> 11.4 (next higher)
+            '11.2' => ['11.4', false],    // Map 11.2 -> 11.4 (next higher)
+            '11.3' => ['11.4', false],    // Map 11.3 -> 11.4 (next higher)
+            '11.5' => ['11.8', false],    // Map 11.5 -> 11.8 (next higher)
+            '11.6' => ['11.8', false],    // Map 11.6 -> 11.8 (next higher)
+            '11.7' => ['11.8', false],    // Map 11.7 -> 11.8 (next higher)
         ],
         // PostgreSQL versions (postgresql service in Upsun -> postgres in DDEV)
-        // DDEV supports PostgreSQL 9-17
+        // DDEV supports PostgreSQL: 9-18 (all versions in this range)
         'postgresql' => [
-            // Current versions
-            '12' => '12',
-            '13' => '13',
-            '14' => '14',
-            '15' => '15',
-            '16' => '16',
-            '17' => '17',
-            // Deprecated versions
-            '9.3' => '9',
-            '9.4' => '9',
-            '9.5' => '9',
-            '9.6' => '9',
-            '10' => '10',
-            '11' => '11'
+            // Exact matches - Continuous range
+            '9' => ['9', true],
+            '9.3' => ['9', true],    // 9.x versions map to 9
+            '9.4' => ['9', true],
+            '9.5' => ['9', true],
+            '9.6' => ['9', true],
+            '10' => ['10', true],
+            '11' => ['11', true],
+            '12' => ['12', true],
+            '13' => ['13', true],
+            '14' => ['14', true],
+            '15' => ['15', true],
+            '16' => ['16', true],
+            '17' => ['17', true],
+            '18' => ['18', true],    // Added in DDEV v1.24.9
         ]
     ];
 
@@ -179,7 +214,28 @@ class DdevConfigGenerator
                 ];
 
                 if (isset(self::DATABASE_VERSION_MAP[$service][$version])) {
-                    $config['database']['version'] = self::DATABASE_VERSION_MAP[$service][$version];
+                    $mapping = self::DATABASE_VERSION_MAP[$service][$version];
+                    $ddevVersion = $mapping[0];
+                    $isExact = $mapping[1];
+
+                    $config['database']['version'] = $ddevVersion;
+
+                    // Warn if mapping is not exact
+                    if (!$isExact) {
+                        $ddevType = self::DATABASE_SERVICE_MAP[$service];
+                        echo "⚠️  WARNING: {$service}:{$version} is not directly supported by DDEV\n";
+                        echo "   Using {$ddevType}:{$ddevVersion} instead (next higher supported version)\n";
+                        echo "   This may cause minor compatibility differences\n";
+                        echo "   Consider updating .upsun/config.yaml to use a version supported by both Upsun and DDEV\n";
+                        echo "   See: https://docs.ddev.com/en/latest/users/configuration/config/#database\n\n";
+                    }
+                } else {
+                    // Version not in mapping at all
+                    $ddevType = self::DATABASE_SERVICE_MAP[$service];
+                    echo "❌ ERROR: {$service}:{$version} is not supported\n";
+                    echo "   DDEV will use its default {$ddevType} version\n";
+                    echo "   Update .upsun/config.yaml to use a supported version\n";
+                    echo "   See: https://docs.ddev.com/en/latest/users/configuration/config/#database\n\n";
                 }
             }
         }


### PR DESCRIPTION

## The Issue

- #16

When users specified an Upsun database version that was not directly supported by DDEV (e.g., mariadb:11.0), the add-on silently omitted the version from the generated config.upsun.yaml, causing DDEV to fall back to its default version without any warning. This created confusion as users got unexpected database versions (mariadb:10.11 default instead of something closer to their specified 11.0).

## How This PR Solves The Issue

1. **Comprehensive Version Mapping**: Expanded DATABASE_VERSION_MAP to include all Upsun/Platform.sh database versions with explicit exact/inexact markers
   - Exact matches (e.g., 11.8 -> 11.8): Direct mapping, no warning
   - Inexact matches (e.g., 11.0 -> 11.4): Maps to next higher DDEV version with warning
   - Unsupported versions: Clear error message with fallback to DDEV default

2. **Warning System**:
   - ⚠️  WARNING for inexact mappings (e.g., mariadb:11.0 -> mariadb:11.4)
   - ❌ ERROR for completely unsupported versions
   - Both provide clear guidance and link to DDEV docs

3. **Database Coverage**:
   - MariaDB: All versions 5.5-11.8 including gaps (10.9, 10.10, 11.0-11.3, 11.5-11.7)
   - MySQL (oracle-mysql): 5.5-8.4 including 8.1-8.3 gaps
   - PostgreSQL: 9-18 (added pg18 support for DDEV v1.24.9+)

4. **Test Coverage**: Added new test fixtures and cases for inexact mapping
   - mariadb-inexact-flex: Tests mariadb:11.0 -> 11.4 mapping with Flex format
   - mariadb-inexact-fixed: Tests mariadb:11.0 -> 11.4 mapping with Fixed format
   - Verifies warning message appears during installation
   - Confirms correct database version is deployed

## Automated Testing Overview

Added 2 new test cases to the unified test suite:
- `test-drupal11-mariadb-inexact-flex`: Verifies inexact mapping with Flex config
- `test-drupal11-mariadb-inexact-fixed`: Verifies inexact mapping with Fixed config

Both tests:
1. Use mariadb:11.0 in configuration (inexact match)
2. Verify warning message during add-on installation
3. Confirm DDEV deploys mariadb:11.4 (next higher supported version)
4. Validate full project functionality with mapped version

Updated test framework to:
- Support multi-part database identifiers (e.g., "mariadb-inexact")
- Capture add-on installation output for warning verification
- Handle both exact and inexact database version expectations

## Release/Deployment Notes

This is a backwards-compatible improvement. Existing projects with exact version matches will see no changes. Projects with unsupported versions will now receive helpful warnings instead of silent fallbacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

