### PR TITLE
fix: Parse service relationship string format correctly, fixes #10, fixes #22

### DIFF
--- a/tests/drupal11-unified.bats
+++ b/tests/drupal11-unified.bats
@@ -83,6 +83,13 @@ set_test_expectations() {
       export EXPECTED_DDEV_DB_CONFIG="mariadb:11.4"
       export EXPECTED_VERSION_WARNING="WARNING: mariadb:11.0 is not directly supported by DDEV"
       ;;
+    "mariadb-generic")
+      export EXPECTED_PHP_VERSION="8.3"
+      export EXPECTED_DB_TYPE="mariadb"
+      export EXPECTED_DB_VERSION="11.8"
+      export EXPECTED_DDEV_DB_CONFIG="mariadb:11.8"
+      export EXPECTED_VERSION_WARNING=""
+      ;;
     "mysql")
       export EXPECTED_PHP_VERSION="8.4"
       export EXPECTED_DB_TYPE="mysql"
@@ -237,5 +244,9 @@ run_unified_test() {
 }
 
 @test "test-drupal11-postgres-fixed" {
+  run_unified_test
+}
+
+@test "test-drupal11-mariadb-generic-flex" {
   run_unified_test
 }

--- a/tests/testdata/platform-configs/mariadb-generic-flex/.upsun/config.yaml
+++ b/tests/testdata/platform-configs/mariadb-generic-flex/.upsun/config.yaml
@@ -1,0 +1,94 @@
+applications:
+  drupal:
+    source:
+      root: /
+    type: php:8.3
+    build:
+      flavor: composer
+    # Installs global dependencies as part of the build process. They're independent of your app's dependencies and
+    # are available in the PATH during the build process and in the runtime environment. They're installed before
+    # the build hook runs using a package manager for the language.
+    # More information: https://docs.upsun.com/create-apps/app-reference/single-runtime-image.html#dependencies
+    dependencies:
+      nodejs:
+        n: "*"
+        npx: "*"
+        yarn: "^1.22.0"
+      php:
+        composer/composer: "^2"
+
+    web:
+      locations:
+        "/":
+          root: "web"
+          expires: 5m
+          passthru: "/index.php"
+          allow: false
+          rules:
+            '\.(avif|webp|jpe?g|png|gif|svgz?|css|js|map|ico|bmp|eot|woff2?|otf|ttf)$':
+              allow: true
+            '^/robots\.txt$':
+              allow: true
+            '^/sitemap\.xml$':
+              allow: true
+            '^/sites/sites\.php$':
+              scripts: false
+            '^/sites/[^/]+/settings.*?\.php$':
+              scripts: false
+        "/sites/default/files":
+          root: "web/sites/default/files"
+          allow: true
+          expires: 5m
+          passthru: "/index.php"
+          scripts: false
+          rules:
+            '^/sites/default/files/(css|js)':
+              expires: 2w
+    variables:
+      env:
+        N_PREFIX: "/app/.global"
+
+    mounts:
+      "/web/sites/default/files": "shared:files/files"
+      "/tmp": "shared:files/tmp"
+      "/private": "shared:files/private"
+      "/.drush": "shared:files/drush"
+      "/drush-backups": "shared:files/drush-backups"
+    relationships:
+      mariadb: 'db:mysql'
+      redis: 'cache:redis'
+      opensearch: 'search:opensearch'
+      memcached: 'memory:memcached'
+
+    hooks:
+      build: |
+        set -e
+        # fast.
+      deploy: |
+        set -e
+        php ./drush/upsun_generate_drush_yml.php
+        cd web
+        bash $PLATFORM_APP_DIR/drush/upsun_deploy_drupal.sh
+
+    runtime:
+      # Enable the redis extension so Drupal can communicate with the Redis cache.
+      extensions:
+        - redis
+        - sodium
+        - apcu
+        - blackfire
+
+services:
+  db:
+    type: mariadb:11.8
+  cache:
+    type: redis:8.0
+  search:
+    type: opensearch:3
+  memory:
+    type: memcached:1.6
+
+routes:
+  "https://{default}/":
+    type: upstream
+    upstream: "drupal:http"


### PR DESCRIPTION
## The Issue

- Fixes #10
- Fixes #22 

The add-on failed to parse Upsun configurations using the official pattern where relationship values reference service names (e.g., mariadb: 'db:mysql'). Only non-standard configurations where the service name matched the database type worked by accident.

## How This PR Solves The Issue

Updated UpsunConfigParser::getDatabaseConfig() to parse relationship string format 'service_name:endpoint' by extracting the service name and looking it up in the services configuration, matching the pattern already implemented in FixedConfigParser. This handles the official Upsun pattern while maintaining backward compatibility with existing configurations.

Also added trim() to Redis config parser for consistency.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/ddev/ddev-upsun/tarball/refs/pull/23/head
ddev restart
```

## Automated Testing Overview

Added new test fixture mariadb-generic-flex that uses generic service name 'db' instead of 'mariadb', and added corresponding test case to drupal11-unified.bats. All existing tests continue to pass, verifying backward compatibility.


